### PR TITLE
fix: add missing kubrick-ui/src/lib/utils.ts

### DIFF
--- a/kubrick-ui/src/lib/utils.ts
+++ b/kubrick-ui/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+    return twMerge(clsx(inputs));
+}


### PR DESCRIPTION
## Problem
Docker build fails with:

Could not load /app/src/lib/utils (imported by src/components/ui/tooltip.tsx): ENOENT: no such file or directory

## Root Cause
The kubrick-ui/src/lib/utils.ts file (standard shadcn/ui utility) is missing from the repository.

This file is imported by 4 UI components:
- button.tsx
- toast.tsx
- tooltip.tsx
- input.tsx

## Fix
Added the standard shadcn/ui cn() utility function that merges Tailwind CSS classes.

## Testing
Verified Docker build succeeds with: docker compose up --build